### PR TITLE
Feat/resolver strategy

### DIFF
--- a/src/lifecycle.mjs
+++ b/src/lifecycle.mjs
@@ -333,6 +333,30 @@ export async function init(worker, crawlPath) {
         log(
           `Ending transformer strategy with name "${transformStrategy.module.name}"`
         );
+
+        if (strategy.transformer?.output?.resolve) {
+          const resolverStrategy = finder("extraction", "resolver");
+          log(
+            `Starting resolver strategy with name "${resolverStrategy.module.name}"`
+          );
+          const args = [
+            generatePath(transformStrategy.module.name, "transformation"),
+          ];
+          const outputPath = generatePath(
+            transformStrategy.module.name,
+            "transformation-resolved"
+          );
+          await extract(
+            resolverStrategy,
+            worker,
+            messageRouter,
+            outputPath,
+            args
+          );
+          log(
+            `Ending resolver strategy with name "${resolverStrategy.module.name}"`
+          );
+        }
       }
     }
   }

--- a/src/strategies/call-block-logs/transformer.mjs
+++ b/src/strategies/call-block-logs/transformer.mjs
@@ -47,12 +47,25 @@ export function onLine(line, contracts) {
         Object.keys(contracts).includes(log.address)
       );
     })
-    .map((log) => ({
-      metadata: {
-        platform: contracts[log.address],
-      },
-      log,
-    }));
+    .map((log) => {
+      return {
+        platform: {
+          ...contracts[log.address],
+        },
+        erc721: {
+          createdAt: parseInt(log.blockNumber, 16),
+          address: log.address,
+          tokens: [
+            {
+              minting: {
+                transactionHash: log.transactionHash,
+              },
+              id: BigInt(log.topics[3]).toString(10),
+            },
+          ],
+        },
+      };
+    });
 
   if (logs.length) {
     return JSON.stringify(logs);

--- a/src/strategies/call-block-logs/transformer.mjs
+++ b/src/strategies/call-block-logs/transformer.mjs
@@ -1,10 +1,18 @@
 // @format
+import { encodeFunctionCall } from "eth-fun";
+
 import logger from "../../logger.mjs";
 import { parseJSON } from "../../utils.mjs";
 
 export const name = "call-block-logs";
 const log = logger(name);
 export const version = "0.1.0";
+
+// Instead of querying at the block number soundxyz NFT
+// was minted, we query at a higher block number because
+// soundxyz changed their tokenURI and the previous one
+// doesn't work anymore. https://github.com/neume-network/data/issues/19
+const BLOCK_NUMBER = "0xe5a51a";
 
 export function onClose() {
   log("closed");
@@ -17,7 +25,13 @@ export function onError(error) {
 }
 
 function validate(contracts) {
-  Object.keys(contracts).forEach((contract) => {
+  const keys = Object.keys(contracts);
+  if (keys.length === 0) {
+    throw new Error(
+      `${name}-transformer needs contract object to have at least one key.`
+    );
+  }
+  keys.forEach((contract) => {
     if (contract !== contract.toLowerCase()) {
       throw new Error("Contract address must be lower key");
     }
@@ -29,7 +43,18 @@ const transferEventSelector =
 const emptyB32 =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
-export function onLine(line, contracts) {
+const signature = {
+  name: "tokenURI",
+  type: "function",
+  inputs: [
+    {
+      name: "tokenId",
+      type: "uint256",
+    },
+  ],
+};
+
+export function onLine(line, contracts = []) {
   validate(contracts);
   let logs;
   try {
@@ -48,11 +73,25 @@ export function onLine(line, contracts) {
       );
     })
     .map((log) => {
+      const tokenId = BigInt(log.topics[3]).toString(10);
       return {
         platform: {
           ...contracts[log.address],
         },
         erc721: {
+          tokenURI: {
+            type: "json-rpc",
+            version: "0.0.1",
+            method: "eth_call",
+            params: [
+              {
+                from: null,
+                to: log.address,
+                data: encodeFunctionCall(signature, [tokenId]),
+              },
+              Math.max(log.blockNumber, BLOCK_NUMBER),
+            ],
+          },
           createdAt: parseInt(log.blockNumber, 16),
           address: log.address,
           tokens: [
@@ -60,7 +99,7 @@ export function onLine(line, contracts) {
               minting: {
                 transactionHash: log.transactionHash,
               },
-              id: BigInt(log.topics[3]).toString(10),
+              id: tokenId,
             },
           ],
         },

--- a/src/strategies/resolver/extractor.mjs
+++ b/src/strategies/resolver/extractor.mjs
@@ -1,0 +1,57 @@
+import { env } from "process";
+import { createInterface } from "readline";
+import { createReadStream } from "fs";
+
+import { deepMapKeys } from "../../utils.mjs";
+
+const version = "0.0.1";
+export const name = "resolver";
+
+const options = {
+  url: env.RPC_HTTP_HOST,
+};
+
+if (env.RPC_API_KEY) {
+  options.headers = {
+    Authorization: `Bearer ${env.RPC_API_KEY}`,
+  };
+}
+
+export async function init(filePath) {
+  const rl = createInterface({
+    input: createReadStream(filePath),
+    crlfDelay: Infinity,
+  });
+
+  const messages = [];
+  for await (const line of rl) {
+    // NOTE: We're ignoring empty lines
+    if (line === "") continue;
+    const pLine = JSON.parse(line);
+
+    for (let elem of pLine) {
+      // TODO: we might also need a deepMapKeys filter... because otherwise we're
+      // just going to find individual keys and not the worker objects within
+      // the tree
+      deepMapKeys(elem, (key, value) => {
+        console.log(value);
+        if (value && value.type) {
+          messages.push({ ...value, metadata: { key } });
+        }
+      });
+    }
+  }
+  console.log(messages);
+
+  return {
+    messages: [],
+    write: null,
+  };
+}
+
+export function update(message) {
+  return {
+    messages: [],
+    write: null,
+  };
+}

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,3 +1,20 @@
+// @format
+
+export function deepMapKeys(obj, cb) {
+  Object.keys(obj).map((key) => {
+    const value = obj[key];
+    if (Array.isArray(value)) {
+      for (let elem of value) {
+        deepMapKeys(elem, cb);
+      }
+    } else if (value !== null && typeof value === "object") {
+      deepMapKeys(value, cb);
+    } else {
+      cb(key, value);
+    }
+  });
+}
+
 export function parseJSON(value, distance = 10) {
   let parsed;
   try {

--- a/test/strategies/call-block-logs/transformer_test.mjs
+++ b/test/strategies/call-block-logs/transformer_test.mjs
@@ -152,22 +152,96 @@ test("call-block-logs transformer", (t) => {
   t.truthy(res0);
   t.truthy(res1);
   const parsed = [...JSON.parse(res0), ...JSON.parse(res1)];
-  t.plan(parsed.length * 6 + 5);
-  t.is(parsed.length, 5);
-  t.is(parsed[4].log.address, "0xca13eaa6135d719e743ffebb5c26de4ce2f9600c");
-  t.is(parsed[4].metadata.platform.name, "sound");
-  for (let { metadata, log } of parsed) {
-    t.truthy(metadata.platform);
-    t.truthy(metadata.platform.name);
-    t.truthy(log.address);
-    t.truthy(log.topics);
-    t.is(
-      log.topics[0],
-      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-    );
-    t.is(
-      log.topics[1],
-      "0x0000000000000000000000000000000000000000000000000000000000000000"
-    );
-  }
+  t.deepEqual(parsed[0], {
+    platform: {
+      name: "zora",
+    },
+    erc721: {
+      createdAt: 14005508,
+      address: "0xabefbc9fd2f806065b4f3c237d4b59d9a97bcac7",
+      tokens: [
+        {
+          minting: {
+            transactionHash:
+              "0x578e40828fa70d7bcb95df6ac42ea5d4367729daac34faa5d8aba839e8196fcc",
+          },
+          id: "7437",
+        },
+      ],
+    },
+  });
+  t.deepEqual(parsed[1], {
+    platform: {
+      name: "catalog",
+      version: "2.0.0",
+    },
+    erc721: {
+      createdAt: 14617046,
+      address: "0x0bc2a24ce568dad89691116d5b34deb6c203f342",
+      tokens: [
+        {
+          minting: {
+            transactionHash:
+              "0x15688480a318ba0c14a6462466a9ed000dd70212b16cf669b627c3eaea5ee4ca",
+          },
+          id: "1",
+        },
+      ],
+    },
+  });
+  t.deepEqual(parsed[2], {
+    platform: {
+      name: "noizd",
+    },
+    erc721: {
+      createdAt: 14602138,
+      address: "0xf5819e27b9bad9f97c177bf007c1f96f26d91ca6",
+      tokens: [
+        {
+          minting: {
+            transactionHash:
+              "0x85496568ab90ac589046d89f5b25ac2739535a2dd146e92a5858ba7deee80296",
+          },
+          id: "40",
+        },
+      ],
+    },
+  });
+  t.deepEqual(parsed[3], {
+    platform: {
+      name: "mintsongs",
+      version: "2.0.0",
+    },
+    erc721: {
+      createdAt: 14837298,
+      address: "0x2b5426a5b98a3e366230eba9f95a24f09ae4a584",
+      tokens: [
+        {
+          minting: {
+            transactionHash:
+              "0x922fa24135d2d38aea91b43b2d7334063bff3e98a4e63f666a0db1e446f2963c",
+          },
+          id: "18",
+        },
+      ],
+    },
+  });
+  t.deepEqual(parsed[4], {
+    platform: {
+      name: "sound",
+    },
+    erc721: {
+      createdAt: 14757111,
+      address: "0xca13eaa6135d719e743ffebb5c26de4ce2f9600c",
+      tokens: [
+        {
+          minting: {
+            transactionHash:
+              "0x963e9bfc038f87742cc6cd300b178fb8bd33fd6c2de5ee12b37081d23c16af73",
+          },
+          id: "680564733841876926926749214863536422962",
+        },
+      ],
+    },
+  });
 });

--- a/test/utils_test.mjs
+++ b/test/utils_test.mjs
@@ -5,7 +5,38 @@ import {
   anyIpfsToNativeIpfs,
   breakdownIpfs,
   ifIpfsConvertToNativeIpfs,
+  deepMapKeys,
 } from "../src/utils.mjs";
+
+test("deep map object keys", (t) => {
+  const obj = {
+    a: 1,
+    b: {
+      c: 2,
+    },
+    d: {},
+    e: [],
+    f: [3],
+    g: [{ h: 4 }],
+    i: [{ j: { k: [{ l: 5 }] } }],
+    m: null,
+    n: undefined,
+    o: 0,
+    p: true,
+    q: false,
+  };
+  t.plan(8);
+  deepMapKeys(obj, (key, value) => {
+    if (key === "a") t.is(value, 1);
+    if (key === "c") t.is(value, 2);
+    if (key === "h") t.is(value, 4);
+    if (key === "l") t.is(value, 5);
+    if (key === "m") t.is(value, null);
+    if (key === "o") t.is(value, 0);
+    if (key === "p") t.is(value, true);
+    if (key === "q") t.is(value, false);
+  });
+});
 
 test("json parser parses", (t) => {
   const data = '{"hello": "world", "invalid": "string"}';


### PR DESCRIPTION
- [x] Implement proper deepMapObjects function that can filter out worker message JSON schemas
- [ ] Make constructing worker messages in lifecycle more readable
- [ ] Do a successful test run of resolver with call-block-logs
- [ ] strip call-block-logs edits from PR to get it into main branch quickly
- [ ] Open an issue and PR at /schema to specify the `transformer.output` path